### PR TITLE
Use collect instead of filter

### DIFF
--- a/client/src/main/scala/skuber/api/watch/WatchSource.scala
+++ b/client/src/main/scala/skuber/api/watch/WatchSource.scala
@@ -84,12 +84,9 @@ private[api] object WatchSource {
 
       val outboundFlow: Flow[StreamElement[O], WatchEvent[O], NotUsed] =
         Flow[StreamElement[O]]
-          .filter(_.isInstanceOf[Result[O]])
-          .map{
+          .collect {
             case Result(_, event) => event
-            case _ => throw new K8SException(Status(message = Some("Error processing watch events.")))
           }
-
 
       val feedbackFlow: Flow[StreamElement[O], (HttpRequest, Start[O]), NotUsed] =
         Flow[StreamElement[O]].scan(StreamContext(None, Waiting)){(cxt, next) =>


### PR DESCRIPTION
Since Akka 2.6.2 `filter` will prefetch one element. This will not change overall output of a stream but changes timing of when demand is propagated. In `WatchSourceSpec` it will lead to an extra request being made even if there's no demand yet from the consumer. In general, the test should be hardened not to fail if these details change but for now this simple change will prevent the prefetching because `collect` does not (yet?) prefetch elements.

Great work, @seglo, pinpointing the problem to the filter change in https://github.com/akka/akka/pull/28467.